### PR TITLE
grafana系のバージョンを固定

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "15672:15672"
 
   tempo:
-    image: grafana/tempo
+    image: grafana/tempo:1.5.0
     extra_hosts: ['host.docker.internal:host-gateway']
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
@@ -16,7 +16,7 @@ services:
       - "9411:9411"
 
   loki:
-    image: grafana/loki
+    image: grafana/loki:2.7.4
     extra_hosts: ['host.docker.internal:host-gateway']
     command: [ "-config.file=/etc/loki/local-config.yaml" ]
     ports:
@@ -39,7 +39,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:9.4.3
     extra_hosts: ['host.docker.internal:host-gateway']
     volumes:
       - ./config/grafana/datasources:/etc/grafana/provisioning/datasources:ro


### PR DESCRIPTION
tempoが動かなくなっていた（コンテナの起動に失敗する）

https://github.com/grafana/tempo/pull/2004 で、2.xでのクリーンアップで動かなくなる模様
1.xの最新を指定しました。

他は動くけれど一応今の最新で。